### PR TITLE
Support StringInterpolationExprSyntax

### DIFF
--- a/Tests/SwiftConstCoreTests/Detectors/DuplicationDetectorTests.swift
+++ b/Tests/SwiftConstCoreTests/Detectors/DuplicationDetectorTests.swift
@@ -22,14 +22,15 @@ struct A {
         print("bbb")
         print("ccc")
 
-        let a = ""
-        let b = ""
-        let c = \"\"\"
-\"\"\"
+        let a = "foo"
+        let b = "\\(a)"
         let d = \"\"\"
-        \"\"\"
+            ddd
+\"\"\"
 
-        return "bbb"
+        print("ccc \\(b) ddd")
+
+        return "bbb" + "bar"
     }
 }
 """
@@ -38,10 +39,14 @@ struct A {
         let result = DuplicationDetector(syntax: syntax).detect()
         
         XCTAssertEqual(result, [
-            .init(value: "\"aaa\"", line: 2, column: 15),
-            .init(value: "\"aaa\"", line: 5, column: 22),
-            .init(value: "\"bbb\"", line: 6, column: 15),
-            .init(value: "\"bbb\"", line: 16, column: 16)]
+            .init(value: "aaa", line: 2, column: 15),
+            .init(value: "aaa", line: 5, column: 22),
+            .init(value: "bbb", line: 6, column: 15),
+            .init(value: "ccc", line: 7, column: 15),
+            .init(value: "ddd", line: 11, column: 17),
+            .init(value: "ccc", line: 15, column: 16),
+            .init(value: "ddd", line: 15, column: 24),
+            .init(value: "bbb", line: 17, column: 16)]
         )
     }
 }

--- a/Tests/SwiftConstCoreTests/Visitors/StringVisitorTests.swift
+++ b/Tests/SwiftConstCoreTests/Visitors/StringVisitorTests.swift
@@ -26,9 +26,12 @@ struct A {
         let a = ""
         let b = ""
         a = b
+
+        print("ccc \\(b)")
     }
 }
 """
+
         let url = createSourceFile(from: input)
         let syntax = try! SyntaxTreeParser.parse(url)
         
@@ -36,10 +39,11 @@ struct A {
         syntax.walk(StringVisitor(dataStore: dataStore))
         
         XCTAssertEqual(dataStore.fileStrings, [
-            .init(value: "\"ddd\"", line: 2, column: 15),
-            .init(value: "\"aaa\"", line: 6, column: 22),
-            .init(value: "\"bbb\"", line: 7, column: 15),
-            .init(value: "\"ccc\"", line: 8, column: 16)]
+            .init(value: "ddd", line: 2, column: 15),
+            .init(value: "aaa", line: 6, column: 22),
+            .init(value: "bbb", line: 7, column: 15),
+            .init(value: "ccc", line: 8, column: 16),
+            .init(value: "ccc", line: 14, column: 16)]
         )
     }
 }


### PR DESCRIPTION
## Overview

We didn't visit `StringInterpolationExprSyntax`, so SwiftConst fully doesn't detect repeating strings. This change enables to detect all the strings, plus display the strings in nicer format.

## Contents

- [x] Visit `StringSegmentSyntax`
- [x] Trim quotes and whitespaces