### PR TITLE
Adapt new StringLiteralExpr in SwiftSyntax

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -48,10 +48,10 @@
       },
       {
         "package": "SwiftSyntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax.git",
+        "repositoryURL": "https://github.com/kitasuke/swift-syntax.git",
         "state": {
-          "branch": "xcode11-beta1",
-          "revision": "fdcbd4bfea2e833467e16d7962c4110c14382b56",
+          "branch": "develop",
+          "revision": "21cb305eb9d568dcaef75cedc9bea0fda85c43ff",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "SwiftConst",
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-syntax.git", .revision("xcode11-beta1")),
+        .package(url: "https://github.com/kitasuke/swift-syntax.git", .branch("develop")), // use master commit teporally
         .package(url: "https://github.com/Carthage/Commandant.git", from: "0.15.0"),
         .package(url: "https://github.com/JohnSundell/Files.git", from: "3.1.0")
     ],

--- a/Sources/SwiftConstCore/Visitors/StringVisitor.swift
+++ b/Sources/SwiftConstCore/Visitors/StringVisitor.swift
@@ -33,19 +33,4 @@ public struct StringVisitor: SyntaxVisitor {
         
         return .skipChildren
     }
-    
-    public mutating func visit(_ node: StringLiteralExprSyntax) -> SyntaxVisitorContinueKind {
-        // ignore empty string. e.g. "\"foo\"" or "\"\"\"\n   bar\"\"\""
-        // TODO: "\"" is unexpectedly ignored for now
-        let value = node.stringLiteral.text
-            .trimmingCharacters(in: CharacterSet(charactersIn: "\"").union(.whitespacesAndNewlines))
-        guard !value.isEmpty else {
-            return .skipChildren
-        }
-        
-        let sourceRange = node.sourceRange(converter: SourceLocationConverter(file: filePath, tree: syntax))
-        let stringLiteral = FileString(value: value, line: sourceRange.start.line ?? 0, column: sourceRange.start.column ?? 0)
-        dataStore.fileStrings.append(stringLiteral)
-        return .skipChildren
-    }
 }

--- a/Tests/SwiftConstCoreTests/Detectors/DuplicationDetectorTests.swift
+++ b/Tests/SwiftConstCoreTests/Detectors/DuplicationDetectorTests.swift
@@ -39,14 +39,14 @@ struct A {
         let result = DuplicationDetector(filePath: "", syntax: syntax).detect()
         
         XCTAssertEqual(result, [
-            .init(value: "aaa", line: 2, column: 15),
-            .init(value: "aaa", line: 5, column: 22),
-            .init(value: "bbb", line: 6, column: 15),
-            .init(value: "ccc", line: 7, column: 15),
-            .init(value: "ddd", line: 11, column: 17),
+            .init(value: "aaa", line: 2, column: 16),
+            .init(value: "aaa", line: 5, column: 23),
+            .init(value: "bbb", line: 6, column: 16),
+            .init(value: "ccc", line: 7, column: 16),
+            .init(value: "ddd", line: 11, column: 20),
             .init(value: "ccc", line: 15, column: 16),
             .init(value: "ddd", line: 15, column: 24),
-            .init(value: "bbb", line: 17, column: 16)]
+            .init(value: "bbb", line: 17, column: 17)]
         )
     }
 }

--- a/Tests/SwiftConstCoreTests/Visitors/StringVisitorTests.swift
+++ b/Tests/SwiftConstCoreTests/Visitors/StringVisitorTests.swift
@@ -40,10 +40,10 @@ struct A {
         syntax.walk(&visitor)
         
         XCTAssertEqual(dataStore.fileStrings, [
-            .init(value: "ddd", line: 2, column: 15),
-            .init(value: "aaa", line: 6, column: 22),
-            .init(value: "bbb", line: 7, column: 15),
-            .init(value: "ccc", line: 8, column: 16),
+            .init(value: "ddd", line: 2, column: 16),
+            .init(value: "aaa", line: 6, column: 23),
+            .init(value: "bbb", line: 7, column: 16),
+            .init(value: "ccc", line: 8, column: 17),
             .init(value: "ccc", line: 14, column: 16)]
         )
     }


### PR DESCRIPTION
## Overview

New StringLiteralExpr's introduced to consolidate StringInterpolatedExpr and StringLiteralExpr to have same interface. This PR adapts the literal expr